### PR TITLE
Update FB to META

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Tickers:
  -  AMD  [  Advanced Micro Devices  ]
  -  NVDA  [  Nvidia Corp  ]
  -  SBUX  [  Starbucks Corp  ]
- -  FB  [  Meta Platforms, Inc. Class A Common Stock  ]
+ -  META  [  Meta Platforms, Inc. Class A Common Stock  ]
  -  HOOD  [  Robinhood Markets, Inc. Class A Common Stock  ]
 ```
 
@@ -118,7 +118,7 @@ Not sure, haven't been able to test it.
 
 These are not in order of priority.
 
-- Run inside docker container.
-- Some kind of build process. tests?
+-   Run inside docker container.
+-   Some kind of build process. tests?
 
-- v2.0 - Instead of 2 separate roles ( Server and GUI(s)), use raft to establish the leader amongst GUIs.
+-   v2.0 - Instead of 2 separate roles ( Server and GUI(s)), use raft to establish the leader amongst GUIs.

--- a/cmd/cli/server.go
+++ b/cmd/cli/server.go
@@ -42,7 +42,7 @@ func newServerCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&cfg.LeaderConfig.TickerList, "tickers", "t", "AAPL,AMD,NVDA,SBUX,FB,HOOD", "A comma separated list of tickers to display on the ticker wall.")
+	cmd.Flags().StringVarP(&cfg.LeaderConfig.TickerList, "tickers", "t", "AAPL,AMD,NVDA,SBUX,META,HOOD", "A comma separated list of tickers to display on the ticker wall.")
 
 	// Ports
 	cmd.Flags().IntVarP(&cfg.GRPCPort, "grpc-port", "g", 6886, "Which port the GRPC Server should bind to.")


### PR DESCRIPTION
The ticker symbol for facebook/meta has since changed. Updating to keep this correct. 